### PR TITLE
fix(#16): fixed gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@
 hs_err_pid*
 replay_pid*
 
+# Maven
 target/
 pom.xml.tag
 pom.xml.releaseBackup

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -14,7 +14,6 @@ dist-ssr
 
 # Editor directories and files
 .vscode/*
-!.vscode/extensions.json
 .idea
 .DS_Store
 *.suo

--- a/frontend/.vscode/extensions.json
+++ b/frontend/.vscode/extensions.json
@@ -1,3 +1,0 @@
-{
-  "recommendations": ["svelte.svelte-vscode"]
-}


### PR DESCRIPTION
closes #16 
problem war die .gitignore im frontend ordner. allgemein wurden .vscode dateien ignoriert, aber im .gitignore des frontend ordners wurde die extensions.json wieder erlaubt. dies wollten wir nicht, daher die änderung.